### PR TITLE
Add support for direct input binding on ActivityTrigger parameters

### DIFF
--- a/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/CompleteOrchestrationTests.cs
+++ b/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/CompleteOrchestrationTests.cs
@@ -32,6 +32,21 @@ namespace Forte.Functions.Testable.Tests.InMemoryOrchestration
         }
 
         [TestMethod]
+        public async Task Can_execute_direct_bound_durable_activities()
+        {
+            var client = new InMemoryOrchestrationClient(typeof(Funcs).Assembly, _services);
+            var instanceId = await client
+                .StartNewAsync(nameof(Funcs.DurableFunctionWithDirectBinding), null);
+
+            await client.WaitForOrchestrationToReachStatus(instanceId, OrchestrationRuntimeStatus.Completed);
+
+            var status = await client.GetStatusAsync(instanceId);
+
+            TestUtil.LogHistory(status, Console.Out);
+            Assert.AreEqual(OrchestrationRuntimeStatus.Completed, status.RuntimeStatus);
+        }
+
+        [TestMethod]
         public async Task Can_execute_durable_function_with_output()
         {
             var input = new TestFunctionInput();

--- a/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithDirectBinding.cs
+++ b/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithDirectBinding.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Forte.Functions.Testable.Tests.InMemoryOrchestration.TestFunctions
+{
+    public partial class Funcs
+    {
+        [FunctionName(nameof(DurableFunctionWithDirectBinding))]
+        public static async Task DurableFunctionWithDirectBinding(
+            [OrchestrationTrigger] DurableOrchestrationContextBase context)
+        {
+            await context.CallActivityAsync(nameof(AnActivityDirectBinding), new TestFunctionInput
+            {
+                Token = "token"
+            });
+        }
+
+        [FunctionName(nameof(AnActivityDirectBinding))]
+        public static Task AnActivityDirectBinding([ActivityTrigger] TestFunctionInput input)
+        {
+            Assert.AreEqual("token", input.Token);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithMutatedInput.cs
+++ b/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithMutatedInput.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Forte.Functions.Testable.Tests.InMemoryOrchestration.TestFunctions
+{
+    public partial class Funcs
+    {
+        [FunctionName(nameof(DurableFunctionWithMutatedInput))]
+        public static async Task DurableFunctionWithMutatedInput(
+            [OrchestrationTrigger] DurableOrchestrationContextBase context)
+        {
+            var inputBeforeMutation = context.GetInput<TestFunctionInput>();
+            inputBeforeMutation.Token = "mutated orchestrator";
+
+            var inputAfterMutation = context.GetInput<TestFunctionInput>();
+            Assert.AreEqual("original", inputAfterMutation.Token, "Orchestrator should not mutate input source");
+
+            await context.CallActivityAsync(nameof(AnActivityWithMutatedInput), inputAfterMutation);
+
+            Assert.AreEqual("original", inputAfterMutation.Token, "Activity should not share orchestrator input source");
+        }
+
+        [FunctionName(nameof(AnActivityWithMutatedInput))]
+        public static Task AnActivityWithMutatedInput([ActivityTrigger] DurableActivityContextBase context)
+        {
+            var inputBefore = context.GetInput<TestFunctionInput>();
+
+            inputBefore.Token = "mutated activity context";
+
+            var inputAfter = context.GetInput<TestFunctionInput>();
+            Assert.AreEqual("original", inputAfter.Token, "Activity should not mutate input source");
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithRetryActivity.cs
+++ b/src/Forte.Functions.Testable.Tests/InMemoryOrchestration/TestFunctions/Funcs.DurableFunctionWithRetryActivity.cs
@@ -1,59 +1,114 @@
 using System;
-using System.Runtime.InteropServices.ComTypes;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
 
 namespace Forte.Functions.Testable.Tests.InMemoryOrchestration.TestFunctions
 {
+    public static class FuncRetryTracker
+    {
+        public class TrackingContext : IDisposable
+        {
+            public Guid Id { get; } = Guid.NewGuid();
+
+            private readonly IDictionary<string, int> _functionCallTracker = new Dictionary<string, int>();
+
+            public void TrackCall(string functionName)
+            {
+                if (_functionCallTracker.TryGetValue(functionName, out var count))
+                {
+                    _functionCallTracker[functionName] = count + 1;
+                }
+                else
+                {
+                    _functionCallTracker.Add(functionName, 1);
+                }
+            }
+
+            public int GetCallCount(string functionName)
+            {
+                return _functionCallTracker.TryGetValue(functionName, out var count)
+                    ? count
+                    : 0;
+            }
+
+            public void Dispose()
+            {
+                TrackingContexts.Remove(Id);
+            }
+        }
+
+        private static readonly IDictionary<Guid, TrackingContext> TrackingContexts = new Dictionary<Guid, TrackingContext>();
+
+        public static TrackingContext Track()
+        {
+            var ctx = new TrackingContext();
+            TrackingContexts.Add(ctx.Id, ctx);
+            return ctx;
+        }
+
+        public static TrackingContext GetTracker(Guid id)
+        {
+            return TrackingContexts[id];
+        }
+    }
+
     public partial class Funcs
     {
         [FunctionName(nameof(DurableFunctionWithRetrySucceedingActivity))]
         public static async Task DurableFunctionWithRetrySucceedingActivity(
             [OrchestrationTrigger] DurableOrchestrationContextBase context)
         {
-            await context.CallActivityWithRetryAsync(
-                nameof(FailAtGivenCallNoActivity), 
-                new RetryOptions(TimeSpan.FromMilliseconds(1),2){}, 
-                new RetryingActivitySetup(2));
+            using (var tracker = FuncRetryTracker.Track())
+            {
+                await context.CallActivityWithRetryAsync(
+                    nameof(FailAtGivenCallNoActivity),
+                    new RetryOptions(TimeSpan.FromMilliseconds(1), 2) { },
+                    new RetryingActivitySetup
+                    {
+                        TrackerId = tracker.Id,
+                        SucceedAtCallNo = 2
+                    }
+                );
+            }
         }
 
         [FunctionName(nameof(DurableFunctionWithRetryFailingActivity))]
         public static async Task DurableFunctionWithRetryFailingActivity(
             [OrchestrationTrigger] DurableOrchestrationContextBase context)
         {
-            await context.CallActivityWithRetryAsync(
+            using (var tracker = FuncRetryTracker.Track()) {
+                await context.CallActivityWithRetryAsync(
                 nameof(FailAtGivenCallNoActivity),
                 new RetryOptions(TimeSpan.FromMilliseconds(1), 2) { },
-                new RetryingActivitySetup(-1));
+                new RetryingActivitySetup
+                {
+                    TrackerId = tracker.Id,
+                    SucceedAtCallNo = -1
+                });
+            }
         }
 
         [FunctionName(nameof(FailAtGivenCallNoActivity))]
         public static Task FailAtGivenCallNoActivity([ActivityTrigger] DurableActivityContextBase context)
         {
             var activitySetup = context.GetInput<RetryingActivitySetup>();
-            activitySetup.Increment();
+            var tracker = FuncRetryTracker.GetTracker(activitySetup.TrackerId);
+            tracker.TrackCall(nameof(FailAtGivenCallNoActivity));
 
-            if(activitySetup.ShouldSucceed()) return Task.CompletedTask;
+            var currentCallCount = tracker.GetCallCount(nameof(FailAtGivenCallNoActivity));
+            if (currentCallCount == activitySetup.SucceedAtCallNo)
+            {
+                return Task.CompletedTask;
+            }
 
-            throw new Exception("Failing call no " + activitySetup.CallNo);
+            throw new Exception("Failing call no " + currentCallCount);
         }
     }
 
     public class RetryingActivitySetup
     {
-        private int SucceedAtCallNo { get; }
-        public int CallNo { get; private set; }
-
-        public RetryingActivitySetup(int succeedAtCallNo)
-        {
-            SucceedAtCallNo = succeedAtCallNo;
-        }
-
-        public void Increment()
-        {
-            CallNo++;
-        }
-
-        public bool ShouldSucceed() => CallNo == SucceedAtCallNo;
+        public Guid TrackerId { get; set; }
+        public int SucceedAtCallNo { get; set; }
     }
 }

--- a/src/Forte.Functions.Testable/IInMemoryContextInput.cs
+++ b/src/Forte.Functions.Testable/IInMemoryContextInput.cs
@@ -1,0 +1,7 @@
+namespace Forte.Functions.Testable
+{
+    public interface IInMemoryContextInput
+    {
+        T GetInput<T>();
+    }
+}

--- a/src/Forte.Functions.Testable/InMemoryActivityContext.cs
+++ b/src/Forte.Functions.Testable/InMemoryActivityContext.cs
@@ -1,24 +1,36 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.Azure.WebJobs;
+using Newtonsoft.Json.Linq;
 
 namespace Forte.Functions.Testable
 {
     public class InMemoryActivityContext : DurableActivityContextBase
     {
         private readonly DurableOrchestrationContextBase _parentContext;
-        private readonly object _input;
+
+        private object _input;
+        private JToken _serializedInput;
+
+        public object Input
+        {
+            get => _input;
+            set
+            {
+                _input = value;
+                _serializedInput = value == null
+                    ? JValue.CreateNull()
+                    : JToken.FromObject(value);
+            }
+        }
 
         public InMemoryActivityContext(DurableOrchestrationContextBase parentContext, object input)
         {
             _parentContext = parentContext;
-            _input = input;
+            Input = input;
         }
 
         public override T GetInput<T>()
         {
-            return (T)_input;
+            return _serializedInput.ToObject<T>();
         }
     }
 }

--- a/src/Forte.Functions.Testable/InMemoryActivityContext.cs
+++ b/src/Forte.Functions.Testable/InMemoryActivityContext.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Linq;
 
 namespace Forte.Functions.Testable
 {
-    public class InMemoryActivityContext : DurableActivityContextBase
+    public class InMemoryActivityContext : DurableActivityContextBase, IInMemoryContextInput
     {
         private readonly DurableOrchestrationContextBase _parentContext;
 


### PR DESCRIPTION
This PR closes #11 

The goal of this PR is to add support for binding of JSON serializable parameters to the DurableActivityContext input. This feature let the user provide any type that is JSON serializable as the type of the parameter used with the ActivityTrigger attribute. The context input will be automatically deserialized into this value without the user having to call the `GetInput<T>()` method themselves.

To get this feature working, I had to make a change to how inputs are passed from functions to functions. Your previous implementation passed inputs as references which does not properly simulate the nature of durable functions. In a real implementation, those inputs would be serialized and stored in Azure Table Storage to make the orchestration replayable. Because of this, activities must deserialize those inputs every time they get called. This deep-copy behavior is now properly simulated.

This also has the side effect of supporting type decoupling between functions. In a real Azure Functions implementation, the type of the input does not have to be compatible with the type that is passed to `CallActivityAsync()`. The activity will deserialize what it can and leave the rest unused.

Because the input is now deep-copied every time a call to `GetInput<T>()` is made, this broke the retry test suite that abused the invalid referencing behavior. I patched it by introducing a Multi-ton call tracker in the tests.