### PR TITLE
Update nuget packages

### DIFF
--- a/src/Forte.Functions.Testable/Forte.Functions.Testable.csproj
+++ b/src/Forte.Functions.Testable/Forte.Functions.Testable.csproj
@@ -7,16 +7,17 @@
     <Authors>Fredrik Kalseth</Authors>
     <Company>Forte Technology</Company>
     <Product />
-    <Version>2.4</Version>
+    <Version>2.5.0</Version>
     <PackageProjectUrl>https://github.com/fortedigital/Forte.Functions.Testable</PackageProjectUrl>
     <RepositoryUrl>https://github.com/fortedigital/Forte.Functions.Testable</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>azure functions azure-functions azure-functions-v2 durable-functions unit-testing</PackageTags>
-    <AssemblyVersion>2.3.0.0</AssemblyVersion>
-    <FileVersion>2.3.0.0</FileVersion>
+    <AssemblyVersion>2.5.0.0</AssemblyVersion>
+    <FileVersion>2.5.0.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>
       Changelog:
+      2.5 Updated for Microsoft.Azure.DurableTask.Core 2.9.0 and Microsoft.Azure.WebJobs.Extensions.DurableTask 2.7.0
       2.4 Added WaitForCustomStatus(predicate). Updated for DurableTask.Core 2.6.0
       2.3 Added WaitForOrchestrationToReachStatus(status[]) and WaitForOrchestrationToFinish. Added TaskFailed history event to orchestration start failures.
       2.2 Updated for Microsoft.Azure.DurableTask.Core 2.5.1
@@ -30,9 +31,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="2.9.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR fixes a `MissingMethodException` for `Void DurableTask.Core.History.ExecutionCompletedEvent..ctor(Int32, System.String, DurableTask.Core.OrchestrationStatus)` when updating to newest version of DurableTask-packages.

Microsoft.Azure.DurableTask.Core to 2.9.0
Microsoft.Azure.WebJobs.Extensions.DurableTask to 2.7.0